### PR TITLE
Typo fix in achievementMethod.js

### DIFF
--- a/src/api/docs/achievements/achievementMethod.js
+++ b/src/api/docs/achievements/achievementMethod.js
@@ -41,6 +41,6 @@ class ErrorfulExample extends Example {
 
   httpCode() { return 403; }
   data() {
-    return "You are not permitted to preform that action.";
+    return "You are not permitted to perform that action.";
   }
 }


### PR DESCRIPTION
Typo fix "preform" to "perform" in 403 error.
